### PR TITLE
Crypto instead of databases for tokens

### DIFF
--- a/backend/setup.py
+++ b/backend/setup.py
@@ -19,6 +19,7 @@ setup(name = 'fureon',
         'redis',
         'passlib',
         'psycopg2',
+        'itsdangerous',
     ],
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
What it says on the tin.

`validate_token` now takes in only a token, and returns the user that it identifies for (or `None`)